### PR TITLE
Use re.findall to find all matches of a pattern

### DIFF
--- a/Day-02/examples/03-regex-findall.py
+++ b/Day-02/examples/03-regex-findall.py
@@ -3,8 +3,9 @@ import re
 text = "The quick brown fox"
 pattern = r"brown"
 
-search = re.search(pattern, text)
+search = re.findall(pattern, text)
 if search:
-    print("Pattern found:", search.group())
+    print("Pattern found:", search)
+    print("Pattern count:", len(search))
 else:
     print("Pattern not found")


### PR DESCRIPTION
Replaced re.search with re.findall to find all occurrences of the pattern in the text and added a count of the occurrences.