### PR TITLE
Fix regex example by using re.search instead of re.match

### DIFF
--- a/Day-02/examples/03-regex-match.py
+++ b/Day-02/examples/03-regex-match.py
@@ -3,7 +3,7 @@ import re
 text = "The quick brown fox"
 pattern = r"quick"
 
-match = re.match(pattern, text)
+match = re.search(pattern, text)
 if match:
     print("Match found:", match.group())
 else:


### PR DESCRIPTION
## Description

The original example used `re.match()`:

```python
match = re.match(pattern, text)
```
However, re.match() only checks for a match at the beginning of the string. Since "sunny" appears later in:
```python
"Today is a sunny day"
```

the example always returned no match.

This PR updates the example to use re.search() instead:
```python
match = re.search(pattern, text)
```

which searches the entire string and returns the expected result.

## Why this change?

According to Python's official documentation:

re.match() → checks only at the beginning of the string
re.search() → scans through the string for a match

## Reference:
https://docs.python.org/3/library/re.html#search-vs-match 